### PR TITLE
Make OpenSSL and requests optional

### DIFF
--- a/paypalrestsdk/notifications.py
+++ b/paypalrestsdk/notifications.py
@@ -3,8 +3,6 @@ from paypalrestsdk.api import default as default_api
 import paypalrestsdk.util as util
 import binascii
 from base64 import b64decode
-import requests
-from OpenSSL import crypto
 
 
 class Webhook(Create, Find, List, Delete, Replace):
@@ -54,6 +52,8 @@ class WebhookEvent(Find, List, Post):
     def _get_cert(cert_url):
         """Fetches the paypal certificate used to sign the webhook event payload
         """
+        import requests
+        from OpenSSL import crypto
         try:
             r = requests.get(cert_url)
             cert = crypto.load_certificate(crypto.FILETYPE_PEM, str(r.text))
@@ -67,6 +67,7 @@ class WebhookEvent(Find, List, Post):
         """Verify that the webhook payload received is from PayPal,
         unaltered and targeted towards correct recipient
         """
+        from OpenSSL import crypto
         expected_sig = WebhookEvent._get_expected_sig(transmission_id, timestamp, webhook_id, event_body)
         cert = WebhookEvent._get_cert(cert_url)
         try:

--- a/paypalrestsdk/notifications.py
+++ b/paypalrestsdk/notifications.py
@@ -3,6 +3,7 @@ from paypalrestsdk.api import default as default_api
 import paypalrestsdk.util as util
 import binascii
 from base64 import b64decode
+import requests
 
 
 class Webhook(Create, Find, List, Delete, Replace):
@@ -52,7 +53,6 @@ class WebhookEvent(Find, List, Post):
     def _get_cert(cert_url):
         """Fetches the paypal certificate used to sign the webhook event payload
         """
-        import requests
         from OpenSSL import crypto
         try:
             r = requests.get(cert_url)


### PR DESCRIPTION
Until Webhook events are needed, OpenSSL and requests can be optional requirements for the SDK.