### PR TITLE
Update reqs so it doesn't break pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyOpenSSL==0.14
 pycparser==2.10
 requests==2.1.0
 sh==1.09
-six==1.5.2
+six>=1.5.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
   license=license,
   description='The PayPal REST SDK provides Python APIs to create, process and manage payments.',
   long_description=long_description,
-  install_requires=['requests', 'six', 'pyopenssl'],
+  install_requires=['requests', 'six>=1.5', 'pyopenssl'],
   classifiers=[
     'Intended Audience :: Developers',
     'Natural Language :: English',


### PR DESCRIPTION
Without a >= your reqs will break other packages with a similar dependency.

pkg_resources.VersionConflict: (six 1.1.0 (/usr/lib/python2.7/dist-packages), Requirement.parse('six>=1.4.1'))

Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/cryptography/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-3Ct8iQ-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/cryptography
Storing debug log for failure in /root/.pip/pip.log
