### PR TITLE
Propagate non-global API from List

### DIFF
--- a/paypalrestsdk/resource.py
+++ b/paypalrestsdk/resource.py
@@ -133,7 +133,7 @@ class List(Resource):
         except AttributeError:
             # To handle the case when response is JSON Array
             if isinstance(response, list):
-                new_resp = [cls.list_class(elem) for elem in response]
+                new_resp = [cls.list_class(elem, api=api) for elem in response]
                 return new_resp
 
 


### PR DESCRIPTION
When using a non-global API, it is not possible to execute calls that lists content. API should propagate on to the Resource call if the returned resource is a JSON Array response.

As far as I can tell from a quick glance, all tests use global API, which is likely why it was never called. However, using a non-global API instance, this would previously fail due to no api being sent to the base Resource constructor:

```python
import paypalrestsdk

api = paypalrestsdk.Api(...)
paypalrestsdk.WebProfile.all(api=api)
```