### PR TITLE
Implement __contains__ on Resource object

### DIFF
--- a/paypalrestsdk/resource.py
+++ b/paypalrestsdk/resource.py
@@ -50,6 +50,9 @@ class Resource(object):
         except AttributeError:
             self.__data__[name] = self.convert(name, value)
 
+    def __contains__(self, item):
+        return item in self.__data__
+
     def success(self):
         return self.error is None
 

--- a/test/unit_tests/resource_test.py
+++ b/test/unit_tests/resource_test.py
@@ -139,3 +139,11 @@ class TestResource(unittest.TestCase):
         self.assertEqual(list_.api, default)
 
         api.__api__ = original  # Restore original api object
+
+    def test_contains(self):
+        data = {
+            'name': 'testing'
+        }
+        resource = Resource(data)
+        self.assertEqual('name' in resource, True)
+        self.assertEqual('testing' in resource, False)


### PR DESCRIPTION
Sorry for just opening a PR, but there isn't really a contributing guide line listed.

We came across a situation where we wanted to loop over the related_resources on a Payment ```Transaction```. The related_resources is a list of Resources, containing one key (for example, "order"). What we wanted to do, was to loop over this list to find all "orders" resources, in case there were several.

However, Resource didn't implement ```__contains__```, meaning that the only neat way seemed to be to duck type out of it, which in my opinion is ugly in this particular situation.

This PR implements ```__contains__``` on Resource, giving the opportunity to make the following snippet work:

```python
resource_type = 'order'
related_resources = response.transactions[0]['related_resources']
for resource in related_resources:
    if resource_type in resource:
        return resource[resource_type]
```