### PR TITLE
pyOpenSSL == 0.13.1 won't build against newer versions (>= 1.0.2a) of OpenSSL headers / libs

### DIFF
--- a/samples/subscription/ppsubscribe/requirements.txt
+++ b/samples/subscription/ppsubscribe/requirements.txt
@@ -7,7 +7,7 @@ httplib2==0.8
 itsdangerous==0.23
 mock==1.0.1
 nose==1.3.1
-paypalrestsdk==1.2.0
-pyOpenSSL==0.13.1
+paypalrestsdk== 1.11.5
+pyOpenSSL==0.15.1
 requests==2.1.0
 six==1.6.1


### PR DESCRIPTION
Same problem as described here : https://github.com/cloudera/hue/issues/205

    OpenSSL/crypto/crl.c:6:23: error: static declaration of ‘X509_REVOKED_dup’ follows non-static declaration
       static X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
                             ^
      In file included from /usr/include/openssl/ssl.h:156:0,
                       from OpenSSL/crypto/x509.h:17,
                       from OpenSSL/crypto/crypto.h:30,
                       from OpenSSL/crypto/crl.c:3:
      /usr/include/openssl/x509.h:751:15: note: previous declaration of ‘X509_REVOKED_dup’ was here
       X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *rev);
                     ^
      error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
      
      ----------------------------------------
      Failed building wheel for pyOpenSSL
