### PR TITLE
Update URL for /v1/vault/credit-cards/

### DIFF
--- a/paypalrestsdk/vault.py
+++ b/paypalrestsdk/vault.py
@@ -13,6 +13,6 @@ class CreditCard(Find, Create, Delete, Replace, List):
 
         >>> credit_card.create()  # return True or False
     """
-    path = "v1/vault/credit-card"
+    path = "v1/vault/credit-cards"
 
 CreditCard.convert_resources['credit_card'] = CreditCard

--- a/samples/credit_card/create.py
+++ b/samples/credit_card/create.py
@@ -6,7 +6,7 @@
 # The following code demonstrates how
 # can save a Credit Card on PayPal using
 # the Vault API.
-# API used: POST /v1/vault/credit-card
+# API used: POST /v1/vault/credit-cards
 from paypalrestsdk import CreditCard
 import logging
 logging.basicConfig(level=logging.INFO)

--- a/samples/credit_card/find.py
+++ b/samples/credit_card/find.py
@@ -2,7 +2,7 @@
 # This sample code demonstrates how you
 # retrieve a previously saved
 # Credit Card using the 'vault' API.
-# API used: GET /v1/vault/credit-card/{id}
+# API used: GET /v1/vault/credit-cards/{id}
 from paypalrestsdk import CreditCard, ResourceNotFound
 import logging
 logging.basicConfig(level=logging.INFO)

--- a/test/functional_tests/api_test.py
+++ b/test/functional_tests/api_test.py
@@ -32,7 +32,7 @@ class Api(unittest.TestCase):
         self.assertEqual(payment_history['count'], 1)
 
     def test_post(self):
-        credit_card = self.api.post("v1/vault/credit-card", {
+        credit_card = self.api.post("v1/vault/credit-cards", {
             "type": "visa",
             "number": "4417119669820331",
             "expire_month": "11",
@@ -44,7 +44,7 @@ class Api(unittest.TestCase):
         self.assertNotEqual(credit_card.get('id'), None)
 
     def test_bad_request(self):
-        credit_card = self.api.post("v1/vault/credit-card", {})
+        credit_card = self.api.post("v1/vault/credit-cards", {})
         self.assertNotEqual(credit_card.get('error'), None)
 
     def test_expired_token(self):

--- a/test/unit_tests/api_test.py
+++ b/test/unit_tests/api_test.py
@@ -50,16 +50,16 @@ class Api(unittest.TestCase):
     def test_post(self):
         self.api.request.return_value = {'id': 'test'}
         credit_card = self.api.post(
-            "v1/vault/credit-card", self.card_attributes)
+            "v1/vault/credit-cards", self.card_attributes)
 
         self.assertEqual(credit_card.get('error'), None)
         self.assertNotEqual(credit_card.get('id'), None)
 
     def test_bad_request(self):
         self.api.request.return_value = {'error': 'test'}
-        credit_card = self.api.post("v1/vault/credit-card", {})
+        credit_card = self.api.post("v1/vault/credit-cards", {})
 
-        self.api.request.assert_called_once_with('https://api.sandbox.paypal.com/v1/vault/credit-card',
+        self.api.request.assert_called_once_with('https://api.sandbox.paypal.com/v1/vault/credit-cards',
                                                  'POST',
                                                  body={},
                                                  headers={},

--- a/test/unit_tests/vault_test.py
+++ b/test/unit_tests/vault_test.py
@@ -25,7 +25,7 @@ class TestCreditCard(unittest.TestCase):
 
         response = self.credit_card.create()
         self.assertNotEqual(self.credit_card.request_id, None)
-        mock.assert_called_once_with(self.credit_card.api, 'v1/vault/credit-card',
+        mock.assert_called_once_with(self.credit_card.api, 'v1/vault/credit-cards',
                                      self.credit_card_attributes, {'PayPal-Request-Id': self.credit_card.request_id}, None)
         self.assertEqual(response, True)
 
@@ -40,7 +40,7 @@ class TestCreditCard(unittest.TestCase):
         card = paypal.CreditCard.find(self.credit_card.id)
         # python 2.6 compatible
         mock.assert_called_once_with(
-            self.credit_card.api, 'v1/vault/credit-card/' + self.credit_card.id, refresh_token=None)
+            self.credit_card.api, 'v1/vault/credit-cards/' + self.credit_card.id, refresh_token=None)
         self.assertTrue(isinstance(card, paypal.CreditCard))
 
     @patch('test_helper.paypal.Api.delete', autospec=True)
@@ -53,7 +53,7 @@ class TestCreditCard(unittest.TestCase):
         self.credit_card.id = 'CARD-6KP075290X361673LKLKB24A'
         response = self.credit_card.delete()
         mock.assert_called_once_with(
-            self.credit_card.api, 'v1/vault/credit-card/' + self.credit_card.id)
+            self.credit_card.api, 'v1/vault/credit-cards/' + self.credit_card.id)
         self.assertEqual(response, True)
 
     @patch('test_helper.paypal.Api.post', autospec=True)
@@ -65,7 +65,7 @@ class TestCreditCard(unittest.TestCase):
         '''
 
         response = self.credit_card.create()
-        mock.assert_called_once_with(self.credit_card.api, 'v1/vault/credit-card',
+        mock.assert_called_once_with(self.credit_card.api, 'v1/vault/credit-cards',
                                      self.credit_card_attributes, {'PayPal-Request-Id': self.credit_card.request_id}, None)
         self.assertEqual(response, True)
 
@@ -73,7 +73,7 @@ class TestCreditCard(unittest.TestCase):
         duplicate_card.request_id = self.credit_card.request_id
         duplicate_card_response = duplicate_card.create()
 
-        mock.assert_called_with(self.credit_card.api, 'v1/vault/credit-card',
+        mock.assert_called_with(self.credit_card.api, 'v1/vault/credit-cards',
                                 self.credit_card_attributes, {'PayPal-Request-Id': self.credit_card.request_id}, None)
         self.assertEqual(mock.call_count, 2)
         self.assertEqual(duplicate_card_response, True)


### PR DESCRIPTION
The old URL /v1/vault/credit-card/ was being used. Updating to the
one in the documentation /v1/vault/credit-cards/ .

See https://developer.paypal.com/docs/api/vault/#credit-card_create .
Fixes discrepancy mentioned in
https://github.com/paypal/PayPal-node-SDK/issues/222 .