### PR TITLE
Update create Invoice example with shipping cost

### DIFF
--- a/paypalrestsdk/invoices.py
+++ b/paypalrestsdk/invoices.py
@@ -63,8 +63,9 @@ class Invoice(List, Find, Create, Delete, Update, Post):
     def search(cls, params=None, api=None):
         api = api or default_api()
         params = params or {}
+        path = "v1/invoicing"
 
-        url = util.join_url(cls.path, 'search')
+        url = util.join_url(path, 'search')
 
         return Resource(api.post(url, params), api=api)
 

--- a/samples/invoice/create.py
+++ b/samples/invoice/create.py
@@ -51,6 +51,12 @@ invoice = Invoice({
             "postal_code": "97216",
             "country_code": "US"
         }
+    },
+    "shipping_cost": {
+        "amount": {
+            "currency": "USD",
+            "value": 10
+        }
     }
 })
 

--- a/test/unit_tests/invoices_test.py
+++ b/test/unit_tests/invoices_test.py
@@ -112,7 +112,7 @@ class TestInvoice(unittest.TestCase):
         history = paypal.Invoice.search(search_attributes)
 
         mock.assert_called_once_with(
-            self.invoice.api, 'v1/invoicing/invoices/search', search_attributes)
+            self.invoice.api, 'v1/invoicing/search', search_attributes)
         self.assertEqual(history.total_count, 1)
         self.assertTrue(isinstance(history.invoices[0], paypal.Invoice))
 


### PR DESCRIPTION
* add shipping cost on example while creating invoice
* according from the [api](https://developer.paypal.com/docs/api/invoicing/#invoices_search), replace invoice search path from `v1/invoicing/invoices/search/` to `v1/invoicing/search/`