### PR TITLE
Allow OpenIdConnect to allow API settings

### DIFF
--- a/paypalrestsdk/openid_connect.py
+++ b/paypalrestsdk/openid_connect.py
@@ -1,13 +1,13 @@
-from paypalrestsdk.resource import Resource
 import paypalrestsdk.util as util
+from paypalrestsdk.resource import Resource
 from paypalrestsdk.api import default as default_api
+from paypalrestsdk.api import Api
 from paypalrestsdk.config import __version__
 from six import string_types
 
-
 class Base(Resource):
 
-    user_agent = "PayPalSDK/openid-connect-python %s (%s)" % (__version__, default_api.Api.library_details)
+    user_agent = "PayPalSDK/openid-connect-python %s (%s)" % (__version__, Api.library_details)
 
     @classmethod
     def post(cls, action, options=None, headers=None, api=None):

--- a/paypalrestsdk/openid_connect.py
+++ b/paypalrestsdk/openid_connect.py
@@ -1,22 +1,23 @@
 from paypalrestsdk.resource import Resource
 import paypalrestsdk.util as util
-import paypalrestsdk.api as api
+from paypalrestsdk.api import default as default_api
 from paypalrestsdk.config import __version__
 from six import string_types
 
 
 class Base(Resource):
 
-    user_agent = "PayPalSDK/openid-connect-python %s (%s)" % (__version__, api.Api.library_details)
+    user_agent = "PayPalSDK/openid-connect-python %s (%s)" % (__version__, default_api.Api.library_details)
 
     @classmethod
-    def post(cls, action, options=None, headers=None):
-        url = util.join_url(endpoint(), action)
+    def post(cls, action, options=None, headers=None, api=None):
+        api = api or default_api()
+        url = util.join_url(endpoint(api), action)
         body = util.urlencode(options or {})
         headers = util.merge_dict({
             'User-Agent': cls.user_agent,
             'Content-Type': 'application/x-www-form-urlencoded'}, headers or {})
-        data = api.default().http_call(url, 'POST', data=body, headers=headers)
+        data = api.http_call(url, 'POST', data=body, headers=headers)
         return cls(data)
 
 
@@ -28,48 +29,48 @@ class Tokeninfo(Base):
     path = "v1/identity/openidconnect/tokenservice"
 
     @classmethod
-    def create(cls, options=None):
+    def create(cls, options=None, api=None):
         options = options or {}
+        api = api or default_api()
         if isinstance(options, string_types):
             options = {'code': options}
 
         options = util.merge_dict({
             'grant_type': 'authorization_code',
-            'client_id': client_id(),
-            'client_secret': client_secret()
+            'client_id': client_id(api),
+            'client_secret': client_secret(api)
         }, options)
-
-        return cls.post(cls.path, options)
+        return cls.post(cls.path, options, api=api)
 
     @classmethod
-    def create_with_refresh_token(cls, options=None):
+    def create_with_refresh_token(cls, options=None, api=None):
         options = options or {}
+        api = api or default_api()
         if isinstance(options, string_types):
             options = {'refresh_token': options}
-
         options = util.merge_dict({
             'grant_type': 'refresh_token',
-            'client_id': client_id(),
-            'client_secret': client_secret()
+            'client_id': client_id(api),
+            'client_secret': client_secret(api)
         }, options)
 
-        return cls.post(cls.path, options)
+        return cls.post(cls.path, options, api=api)
 
     @classmethod
-    def authorize_url(cls, options=None):
-        return authorize_url(options or {})
+    def authorize_url(cls, options=None, api=None):
+        return authorize_url(options or {}, api=api)
 
-    def logout_url(self, options=None):
-        return logout_url(util.merge_dict({'id_token': self.id_token}, options or {}))
+    def logout_url(self, options=None, api=None):
+        return logout_url(util.merge_dict({'id_token': self.id_token}, options or {}), api=api)
 
-    def refresh(self, options=None):
+    def refresh(self, options=None, api=None):
         options = util.merge_dict({'refresh_token': self.refresh_token}, options or {})
-        tokeninfo = self.__class__.create_with_refresh_token(options)
+        tokeninfo = self.__class__.create_with_refresh_token(options, api=api)
         self.merge(tokeninfo.to_dict())
         return self
 
-    def userinfo(self, options=None):
-        return Userinfo.get(util.merge_dict({'access_token': self.access_token}, options or {}))
+    def userinfo(self, options=None, api=None):
+        return Userinfo.get(util.merge_dict({'access_token': self.access_token}, options or {}), api=api)
 
 
 class Userinfo(Base):
@@ -79,56 +80,63 @@ class Userinfo(Base):
     path = "v1/identity/openidconnect/userinfo"
 
     @classmethod
-    def get(cls, options=None):
+    def get(cls, options=None, api=None):
         options = options or {}
         if isinstance(options, string_types):
             options = {'access_token': options}
         options = util.merge_dict({'schema': 'openid'}, options)
-
-        return cls.post(cls.path, options)
-
-
-def endpoint():
-    return api.default().options.get("openid_endpoint", api.default().endpoint)
+        api = api or default_api()
+        return cls.post(cls.path, options, api=api)
 
 
-def client_id():
-    return api.default().options.get("openid_client_id", api.default().client_id)
+def endpoint(api=None):
+    api = api or default_api()
+    return api.options.get("openid_endpoint", api.endpoint)
 
 
-def client_secret():
-    return api.default().options.get("openid_client_secret", api.default().client_secret)
+def client_id(api=None):
+    api = api or default_api()
+    return api.options.get("openid_client_id", api.client_id)
 
 
-def redirect_uri():
-    return api.default().options.get("openid_redirect_uri")
+def client_secret(api=None):
+    api = api or default_api()
+    return api.options.get("openid_client_secret", api.client_secret)
+
+
+def redirect_uri(api=None):
+    api = api or default_api()
+    return api.options.get("openid_redirect_uri")
 
 
 start_session_path = "/signin/authorize"
 end_session_path = "/webapps/auth/protocol/openidconnect/v1/endsession"
 
 
-def session_url(path, options=None):
-    if api.default().mode == "live":
+def session_url(path, options=None, api=None):
+    api = api or default_api()
+    if api.mode == "live":
         path = util.join_url("https://www.paypal.com", path)
     else:
         path = util.join_url("https://www.sandbox.paypal.com", path)
     return util.join_url_params(path, options or {})
 
 
-def authorize_url(options=None):
+def authorize_url(options=None, api=None):
+    api = api or default_api()
     options = util.merge_dict({
         'response_type': 'code',
         'scope': 'openid',
-        'client_id': client_id(),
-        'redirect_uri': redirect_uri()
+        'client_id': client_id(api),
+        'redirect_uri': redirect_uri(api)
     }, options or {})
-    return session_url(start_session_path, options)
+    return session_url(start_session_path, options, api=api)
 
 
-def logout_url(options=None):
+def logout_url(options=None, api=None):
+    api = api or default_api()
     options = util.merge_dict({
         'logout': 'true',
-        'redirect_uri': redirect_uri()
+        'redirect_uri': redirect_uri(api)
     }, options or {})
-    return session_url(end_session_path, options)
+    return session_url(end_session_path, options, api=api)

--- a/samples/openid_connect.py
+++ b/samples/openid_connect.py
@@ -1,9 +1,13 @@
 import paypalrestsdk
 from paypalrestsdk.openid_connect import Tokeninfo
 
-paypalrestsdk.configure({'openid_client_id': 'CLIENT_ID',
-                         'openid_client_secret': 'CLIENT_SECRET',
-                         'openid_redirect_uri': 'http://example.com'})
+paypalrestsdk.configure({
+    'client_id': 'CLIENT_ID',
+    'client_secret': 'CLIENT_SECRET',
+    'openid_client_id': 'CLIENT_ID',
+    'openid_client_secret': 'CLIENT_SECRET',
+    'openid_redirect_uri': 'http://example.com'
+})
 
 login_url = Tokeninfo.authorize_url({'scope': 'openid profile'})
 

--- a/test/unit_tests/openid_connect_test.py
+++ b/test/unit_tests/openid_connect_test.py
@@ -1,5 +1,7 @@
 from test_helper import unittest, paypal, client_id, client_secret, assert_regex_matches
 from paypalrestsdk.openid_connect import Tokeninfo, Userinfo, authorize_url, logout_url, endpoint, Base
+from paypalrestsdk.api import default as default_api
+from paypalrestsdk.api import Api
 from mock import Mock
 
 
@@ -17,26 +19,26 @@ class TestTokeninfo(unittest.TestCase):
         self.assertRaises(
             paypal.ResourceNotFound, Tokeninfo.create, "invalid-code")
         Base.post.assert_called_once_with('v1/identity/openidconnect/tokenservice', {
-                                          'code': 'invalid-code', 'client_secret': client_secret, 'grant_type': 'authorization_code', 'client_id': client_id})
+                                          'code': 'invalid-code', 'client_secret': client_secret, 'grant_type': 'authorization_code', 'client_id': client_id }, api=default_api())
 
     def test_userinfo(self):
         Base.post.side_effect = paypal.UnauthorizedAccess('', '')
         self.assertRaises(paypal.UnauthorizedAccess, Tokeninfo().userinfo, {})
         Base.post.assert_called_once_with(
-            'v1/identity/openidconnect/userinfo', {'access_token': None, 'schema': 'openid'})
+            'v1/identity/openidconnect/userinfo', {'access_token': None, 'schema': 'openid'}, api=default_api())
 
     def test_refresh(self):
         Base.post.side_effect = paypal.ResourceNotFound('', '')
         self.assertRaises(paypal.ResourceNotFound, Tokeninfo().refresh, {})
         Base.post.assert_called_once_with('v1/identity/openidconnect/tokenservice', {
-                                          'client_secret': client_secret, 'grant_type': 'refresh_token', 'refresh_token': None, 'client_id': client_id})
+                                          'client_secret': client_secret, 'grant_type': 'refresh_token', 'refresh_token': None, 'client_id': client_id}, api=default_api())
 
     def test_create_with_refresh_token(self):
         Base.post.side_effect = paypal.ResourceNotFound('', '')
         self.assertRaises(
             paypal.ResourceNotFound, Tokeninfo.create_with_refresh_token, "invalid-token")
         Base.post.assert_called_once_with('v1/identity/openidconnect/tokenservice', {
-                                          'client_secret': client_secret, 'grant_type': 'refresh_token', 'refresh_token': 'invalid-token', 'client_id': client_id})
+                                          'client_secret': client_secret, 'grant_type': 'refresh_token', 'refresh_token': 'invalid-token', 'client_id': client_id}, api=default_api())
 
 
 class TestUserinfo(unittest.TestCase):
@@ -48,7 +50,7 @@ class TestUserinfo(unittest.TestCase):
         Base.post.side_effect = paypal.UnauthorizedAccess('', '')
         self.assertRaises(paypal.UnauthorizedAccess, Userinfo.get, "invalid")
         Base.post.assert_called_once_with(
-            'v1/identity/openidconnect/userinfo', {'access_token': 'invalid', 'schema': 'openid'})
+            'v1/identity/openidconnect/userinfo', {'access_token': 'invalid', 'schema': 'openid'}, api=default_api())
 
 
 class TestUrls(unittest.TestCase):
@@ -62,6 +64,16 @@ class TestUrls(unittest.TestCase):
 
         self.assertEqual(endpoint(), 'https://api.sandbox.paypal.com')
 
+    def test_authorize_url_with_api(self):
+        custom_api = Api(mode="sandbox", client_id='custom_client_id', client_secret='custom_client_secret', openid_endpoint='https://def.abc', openid_redirect_uri='http://abc.def/')
+        url = authorize_url(api=custom_api)
+        assert_regex_matches(self, url, 'response_type=code')
+        assert_regex_matches(self, url, 'scope=openid')
+        assert_regex_matches(self, url, 'client_id=custom_client_id')
+        assert_regex_matches(self, url, 'redirect_uri=http%3A%2F%2Fabc.def%2F')
+
+        self.assertEqual(endpoint(custom_api), 'https://def.abc')
+
     def test_live_mode_url(self):
         try:
             paypal.configure(
@@ -71,7 +83,6 @@ class TestUrls(unittest.TestCase):
             assert_regex_matches(self, url, 'scope=openid')
             assert_regex_matches(self, url, 'client_id=%s' % (client_id))
             assert_regex_matches(self, url, 'https://www.paypal.com')
-
             self.assertEqual(endpoint(), 'https://api.paypal.com')
         finally:
             paypal.configure(
@@ -89,8 +100,15 @@ class TestUrls(unittest.TestCase):
         url = logout_url()
         assert_regex_matches(self, url, 'logout=true')
 
-    def test_logout_url_options(self):
-        url = logout_url({'id_token': '1234'})
+    def test_logout_url_with_api(self):
+        custom_api = Api(mode="sandbox", client_id='custom_client_id', client_secret='custom_client_secret', openid_endpoint='https://def.abc', openid_redirect_uri='http://abc.def/')
+        url = logout_url(api=custom_api)
+        assert_regex_matches(self, url, 'logout=true')
+        assert_regex_matches(self, url, 'redirect_uri=http%3A%2F%2Fabc.def%2F')
+
+    def test_logout_url_options_uses_options_over_api(self):
+        custom_api = Api(mode="sandbox", client_id='custom_client_id', client_secret='custom_client_secret', openid_endpoint='https://def.abc', openid_redirect_uri='http://abc.def/')
+        url = logout_url({'id_token': '1234'}, api=custom_api)
         assert_regex_matches(self, url, 'id_token=1234')
 
     def test_logout_url_using_tokeninfo(self):


### PR DESCRIPTION
Currently, login with PayPal APIs does not allow you to pass custom `api` object to method calls, allowing merchant to pass custom `clientId` and `secret`.

This PR fixes that by allowing one to pass `api` object. 

#### Example
```py
import paypalrestsdk
from paypalrestsdk.openid_connect import Tokeninfo
from paypalrestsdk.api import Api

api = Api(mode="sandbox", client_id='AYSq3RDGsmBLJE-otTkBtM-jBRd1TCQwFf9RGfwddNXWz0uFU9ztymylOhRS', client_secret='EGnHDxD_qRPdaLdZz8iCr8N7_MzF-YHPTkjs6NKYQvQSBngp4PTTVWkPZRbL', openid_redirect_uri='http://localhost/paypal/PayPal-PHP-SDK/sample/lipp/UserConsentRedirect.php?success=true')

login_url = Tokeninfo.authorize_url({'scope': 'openid profile'}, api)

print(login_url)
```