### PR TITLE
Add authorization example to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ else:
   print(payment.error)
 ```
 
+### Authorize Payment
+
+```pythong
+for link in payment.links:
+    if link.rel == "approval_url":
+        # Convert to str to avoid google appengine unicode issue
+        # https://github.com/paypal/rest-api-sdk-python/pull/58
+        approval_url = str(link.href)
+        print("Redirect for approval: %s" % (approval_url))
+```
+
 ### Execute Payment
 
 ```python

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ else:
 
 ### Authorize Payment
 
-```pythong
+```python
 for link in payment.links:
     if link.rel == "approval_url":
-        # Convert to str to avoid google appengine unicode issue
+        # Convert to str to avoid Google App Engine Unicode issue
         # https://github.com/paypal/rest-api-sdk-python/pull/58
         approval_url = str(link.href)
         print("Redirect for approval: %s" % (approval_url))


### PR DESCRIPTION
Adding example to authorize payments to save time from digging through the samples.