### PR TITLE
Update pip for Python builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 - '3.3'
 - '3.4'
 install:
+- pip install --upgrade pip wheel setuptools
 - pip install -r requirements.txt
 - openssl version -a
 script:


### PR DESCRIPTION
Python 3.3 builds for the 2.0-beta branch have an issue installing:

```
  Downloading cryptography-2.1.4.tar.gz (441kB)
    Complete output from command python setup.py egg_info:
    error in cryptography setup command: Invalid environment marker: platform_python_implementation != 'PyPy'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-r1spq6/cryptography/
```