### PR TITLE
Build clean-up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ addons:
       - openssl
 language: python
 python:
-- '2.7'
-- '3.3'
-- '3.4'
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
 install:
-- pip install -r requirements.txt
-- openssl version -a
+  - pip install -r requirements.txt
+  - openssl version -a
 script:
-- nosetests --with-coverage --cover-package=paypalrestsdk --include=paypalrestsdk/* --exclude=functional*
-
+  - nosetests --with-coverage --cover-package=paypalrestsdk --include=paypalrestsdk/* --exclude=functional*

--- a/paypalrestsdk/api.py
+++ b/paypalrestsdk/api.py
@@ -19,8 +19,8 @@ log = logging.getLogger(__name__)
 class Api(object):
 
     # User-Agent for HTTP request
-    ssl_version = "" if util.older_than_27() else ssl.OPENSSL_VERSION
-    ssl_version_info = None if util.older_than_27() else ssl.OPENSSL_VERSION_INFO
+    ssl_version = ssl.OPENSSL_VERSION
+    ssl_version_info = ssl.OPENSSL_VERSION_INFO
     library_details = "requests %s; python %s; %s" % (
         requests.__version__, platform.python_version(), ssl_version)
     user_agent = "PayPalSDK/PayPal-Python-SDK %s (%s)" % (

--- a/paypalrestsdk/util.py
+++ b/paypalrestsdk/util.py
@@ -50,11 +50,6 @@ def merge_dict(data, *override):
     return result
 
 
-def older_than_27():
-    import sys
-    return True if sys.version_info[:2] < (2, 7) else False
-
-
 def get_member(name):
     """
     Get the paypalrestsdk member class represented by name. Helper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 PyYAML>=3.10
 cffi>=0.8.6
-coverage>=3.7.1
-coveralls>=0.3
-cryptography>=0.6.1
 docopt>=0.6.1
-mock>=1.0.1
-nose>=1.3.0
 pyOpenSSL>=0.15
 pycparser>=2.10
 requests>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules'
   ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+coverage>=3.7.1
+coveralls>=0.3
+mock>=1.0.1
+ndg-httpsclient>=0.3.2
+nose>=1.3.0
+pyasn1>=0.1.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py27,py34,py35,py36,pypy
 
 [testenv]
-commands = 
-    pep8 paypalrestsdk
-    nosetests --include=paypalrestsdk/* --exclude=functional*
-deps =
-    nose>=1.3.0
-    mock>=1.0.1
-    pyopenssl>=0.15
-    ndg-httpsclient>=0.3.2
-    pyasn1>=0.1.6
-    pep8>=1.4.6
-skip_missing_interpreters =
-    true
+usedevelop = False
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+commands = nosetests --include=paypalrestsdk/* --exclude=functional*
+skip_missing_interpreters = true
+
+[testenv:pep8]
+basepython = python2.7
+deps = pycodestyle
+commands = pycodestyle paypalrestsdk


### PR DESCRIPTION
- Drop support of deprecated Python 2.6
- Drop support of EOL Python 3.3
- Add support of Python 3.5/3.6
- Create test-requirements.txt for test requirements