### PR TITLE
Add tests for Sync and Orders

### DIFF
--- a/tests/v1/orders/__init__.py
+++ b/tests/v1/orders/__init__.py
@@ -1,0 +1,5 @@
+
+from tests.v1.orders.orders_cancel_test import *
+from tests.v1.orders.orders_create_test import *
+from tests.v1.orders.orders_get_test import *
+from tests.v1.orders.orders_pay_test import *

--- a/tests/v1/orders/orders_cancel_test.py
+++ b/tests/v1/orders/orders_cancel_test.py
@@ -1,0 +1,31 @@
+import unittest
+import json
+
+from braintreehttp.http_error import HttpError
+from tests.v1.orders.orders_create_test import create_order
+from paypalrestsdk.v1.orders import OrdersCancelRequest, OrdersGetRequest
+from tests.testharness import TestHarness
+
+class OrdersCancelTest(TestHarness):
+
+    def testOrdersCancelTest(self):
+        create_response = create_order(self.client)
+
+        get_request = OrdersGetRequest(create_response.result.id)
+        get_response = self.client.execute(get_request)
+        self.assertEqual(200, get_response.status_code)
+        self.assertIsNotNone(get_response.result)
+
+        request = OrdersCancelRequest(create_response.result.id)
+        response = self.client.execute(request)
+        self.assertEqual(204, response.status_code)
+
+        try:
+            get_request = OrdersGetRequest(create_response.result.id)
+            get_response = self.client.execute(get_request)
+            self.fail()
+        except HttpError as he:
+            self.assertEqual(404, he.status_code)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/v1/orders/orders_create_test.py
+++ b/tests/v1/orders/orders_create_test.py
@@ -1,0 +1,73 @@
+import unittest
+import json
+
+from paypalrestsdk.v1.orders import OrdersCreateRequest
+from tests.testharness import TestHarness
+
+class OrdersCreateTest(TestHarness):
+    def testOrdersCreateTest(self):
+        response = create_order(self.client)
+
+        self.assertEqual(201, response.status_code)
+        self.assertIsNotNone(response.result)
+
+        self.assertIsNotNone(response.result.id)
+        self.assertIsNotNone(response.result.purchase_units)
+        self.assertEqual(2, len(response.result.purchase_units))
+
+        first_purchase_unit = response.result.purchase_units[0]
+        self.assertEqual("test_ref_id1", first_purchase_unit.reference_id)
+        self.assertEqual("USD", first_purchase_unit.amount.currency)
+        self.assertEqual("100.00", first_purchase_unit.amount.total)
+        self.assertEqual("NOT_PROCESSED", first_purchase_unit.status)
+
+        second_purchase_unit = response.result.purchase_units[1]
+        self.assertEqual("test_ref_id2", second_purchase_unit.reference_id)
+        self.assertEqual("USD", second_purchase_unit.amount.currency)
+        self.assertEqual("50.00", second_purchase_unit.amount.total)
+        self.assertEqual("NOT_PROCESSED", second_purchase_unit.status)
+
+        self.assertEqual("https://example.com/return", response.result.redirect_urls.return_url)
+        self.assertEqual("https://example.com/cancel", response.result.redirect_urls.cancel_url)
+
+        self.assertIsNotNone(response.result.create_time)
+
+        self.assertIsNotNone(response.result.links)
+
+        found_approval_url = False
+        for link in response.result.links:
+            if "approval_url" == link.rel:
+                found_approval_url = True
+                self.assertIsNotNone(link.href)
+                self.assertEqual("REDIRECT", link.method)
+        self.assertTrue(found_approval_url)
+
+        self.assertEqual("CREATED", response.result.status)
+
+def create_order(client):
+    request = OrdersCreateRequest()
+    body = {
+        "intent": "SALE",
+        "purchase_units": [{
+            "reference_id": "test_ref_id1",
+            "amount": {
+                "total": "100.00",
+                "currency": "USD"
+            }
+        }, {
+            "reference_id": "test_ref_id2",
+            "amount": {
+                "total": "50.00",
+                "currency": "USD"
+            }
+        }],
+        "redirect_urls": {
+            "cancel_url": "https://example.com/cancel",
+            "return_url": "https://example.com/return"
+        }
+    }
+    request.request_body(body)
+    return client.execute(request)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/v1/orders/orders_get_test.py
+++ b/tests/v1/orders/orders_get_test.py
@@ -1,0 +1,43 @@
+import unittest
+import json
+
+from tests.v1.orders.orders_create_test import create_order
+
+from paypalrestsdk.v1.orders import OrdersGetRequest
+from tests.testharness import TestHarness
+
+class OrdersGetTest(TestHarness):
+
+    def testOrdersGetTest(self):
+        create_response = create_order(self.client)
+
+        get_request = OrdersGetRequest(create_response.result.id)
+        get_response = self.client.execute(get_request)
+        self.assertEqual(200, get_response.status_code)
+        self.assertIsNotNone(get_response.result)
+
+        created_order = create_response.result
+        retrieved_order = get_response.result
+
+        self.assertEqual(created_order.id, retrieved_order.id)
+        self.assertEqual(len(created_order.purchase_units), len(retrieved_order.purchase_units))
+
+        self.assertEqual(created_order.redirect_urls.return_url, retrieved_order.redirect_urls.return_url)
+        self.assertEqual(created_order.redirect_urls.cancel_url, retrieved_order.redirect_urls.cancel_url)
+
+        self.assertEqual(created_order.create_time, retrieved_order.create_time)
+
+        self.assertIsNotNone(retrieved_order.links)
+
+        found_approval_url = False
+        for link in retrieved_order.links:
+            if "approval_url" == link.rel:
+                found_approval_url = True
+                self.assertIsNotNone(link.href)
+                self.assertEqual("REDIRECT", link.method)
+        self.assertTrue(found_approval_url)
+
+        self.assertEqual("CREATED", retrieved_order.status)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/v1/orders/orders_pay_test.py
+++ b/tests/v1/orders/orders_pay_test.py
@@ -1,0 +1,25 @@
+import unittest
+import json
+
+from paypalrestsdk.v1.orders import OrdersPayRequest
+from tests.testharness import TestHarness
+
+class OrdersPayTest(TestHarness):
+    def testOrdersPayTest(self):
+        self.skipTest("Tests that use this class must be ignored when run in an automated environment because executing an order will require approval via the order's approval_url")
+
+        order_id = "4KR73208J46569503"
+        request = OrdersPayRequest(order_id)
+        request.request_body({
+            "disbursement_mode": "INSTANT"
+        })
+
+        response = self.client.execute(request)
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.result)
+
+        self.assertEqual(order_id, response.result.order_id)
+        self.assertEqual("APPROVED", response.result.status)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/v1/sync/__init__.py
+++ b/tests/v1/sync/__init__.py
@@ -1,0 +1,2 @@
+
+from tests.v1.sync.search_get_test import *

--- a/tests/v1/sync/search_get_test.py
+++ b/tests/v1/sync/search_get_test.py
@@ -1,0 +1,47 @@
+import unittest
+import json
+
+from paypalrestsdk.v1.sync import SearchGetRequest
+from tests.testharness import TestHarness
+
+class SearchGetTest(TestHarness):
+
+    def testSearchMultipleTransactionsBetweenDates(self):
+        request = SearchGetRequest()
+        request.start_date("2018-01-22T00:00:00+00:00")
+        request.end_date("2018-01-23T00:00:00+00:00")
+
+        response = self.client.execute(request)
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.result)
+
+        self.assertEqual(77, response.result.total_items)
+        self.assertIsNotNone(response.result.transaction_details)
+        self.assertEqual(77, len(response.result.transaction_details))
+
+    def testSearchGetSpecifictransactionId(self):
+        request = SearchGetRequest()
+        transaction_id = "4LJ583775B2362642"
+        request.transaction_id(transaction_id)
+
+        response = self.client.execute(request)
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.result)
+
+        self.assertIsNotNone(response.result.transaction_details)
+        self.assertEqual(1, len(response.result.transaction_details))
+
+        transaction_details = response.result.transaction_details[0]
+        self.assertIsNotNone(transaction_details)
+        transaction_info = transaction_details.transaction_info
+        self.assertIsNotNone(transaction_info)
+
+        self.assertEqual(transaction_id, transaction_info.transaction_id)
+        transaction_amount = transaction_info.transaction_amount
+        self.assertIsNotNone(transaction_amount)
+
+        self.assertEqual("USD", transaction_amount.currency_code)
+        self.assertEqual("10.00", transaction_amount.value)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The API code was added already to the 2.0-beta branch, but just need to add the tests.